### PR TITLE
Update setup.py, exclude 'tests'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/rokam/sunweg",
     install_requires=requires,
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['tests','tests.*']),
     python_requires=">=3.10",
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Otherwise:

```
 * The following unexpected files/directories were found top-level
 * in the site-packages directory:
 *
 *   /usr/lib/python3.11/site-packages/tests
 *
 * This is most likely a bug in the build system.  More information
 * can be found in the Python Guide:
 * https://projects.gentoo.org/python/guide/qawarn.html#stray-top-level-files-in-site-packages
```